### PR TITLE
新增 RABBIT_UPDATE_CHECK_DISABLED 环境变量以跳过更新检查

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,4 +109,5 @@ Environment variables `MODE` (master/worker), `JWT_SECRET`, `NODE_SECRET`, `MAST
 - Docker socket must be mounted into the container/binary for container management
 - Time sync between Master and Worker nodes must be within 1 hour (node auth uses JWT with 1-hour tolerance)
 - The backend's WebSocket terminal handler lives in `router/router.go` — any changes to the exec/session protocol should be tested against the xterm.js frontend client
+- Set `RABBIT_UPDATE_CHECK_DISABLED=true` to skip the update check (no outbound `MANIFEST_URL` fetch) — see `backend/service/update.go`
 

--- a/backend/service/update.go
+++ b/backend/service/update.go
@@ -29,6 +29,9 @@ const (
 	updateBinaryDir           = "/tmp/rabbit-panel-update"
 	updateStatePath           = "/tmp/rabbit-panel-update.state"
 	updateResultPath          = "/tmp/rabbit-panel-update.result"
+
+	// When set to true, the update check (manifest fetch) is skipped entirely.
+	updateCheckDisabledEnv = "RABBIT_UPDATE_CHECK_DISABLED"
 )
 
 type BuildInfo struct {
@@ -177,6 +180,26 @@ func (s *UpdateService) Check(ctx context.Context) (*UpdateCheckResult, error) {
 	settings, err := s.loadSettings()
 	if err != nil {
 		return nil, err
+	}
+
+	if updateCheckDisabled() {
+		deploy := s.DetectDeployConfig()
+		return &UpdateCheckResult{
+			CurrentVersion:   s.buildInfo.Version,
+			CurrentCommit:    s.buildInfo.Commit,
+			CurrentBuildTime: s.buildInfo.BuildTime,
+			LatestVersion:    "",
+			HasUpdate:        false,
+			DeployMode:       deploy.Mode,
+			Image:            deploy.Image,
+			ImageTag:         deploy.ImageTag,
+			CanUpdate:        false,
+			Message:          "update check is disabled",
+			LastCheckTime:    settings.LastCheckTime,
+			LastUpdateTime:   settings.LastUpdateTime,
+			LastUpdateStatus: settings.LastUpdateStatus,
+			LastUpdateError:  settings.LastUpdateError,
+		}, nil
 	}
 
 	manifest, err := s.fetchManifest(ctx)
@@ -1006,6 +1029,11 @@ func getEnv(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func updateCheckDisabled() bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(updateCheckDisabledEnv)))
+	return value == "true" || value == "1" || value == "yes" || value == "on"
 }
 
 func ensureSystemctlAvailable() error {

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -21,6 +21,7 @@ services:
       - RABBIT_IMAGE_TAG=latest
       - RABBIT_HOST_PROJECT_DIR=/root/rabbit-panel
       - RABBIT_COMPOSE_FILE=docker-compose.deploy.yml
+      # - RABBIT_UPDATE_CHECK_DISABLED=true  # set to true to skip the update check (no manifest fetch)
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3958/api/health"]
       interval: 30s


### PR DESCRIPTION
设置 RABBIT_UPDATE_CHECK_DISABLED=true 时，Check() 直接返回， 不再向外请求 MANIFEST_URL，前端不会显示更新提示。